### PR TITLE
fix: add `float: left` as fallback

### DIFF
--- a/src/scss/components/_it-me.scss
+++ b/src/scss/components/_it-me.scss
@@ -5,6 +5,7 @@
   &__image {
     @include mixins.img-drop-shadow;
 
+    float: left;
     float: inline-start;
     max-width: min(30vw, 200px);
     clip-path: circle(50%);


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
Apparently, Chrome doesn't support logical direction values for `float` 🙄 