### PR TITLE
feat: provide fallback for masonry layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "dustinwhisman-com",
       "version": "0.1.0",
       "license": "CC BY 4.0",
+      "dependencies": {
+        "image-size": "^1.0.2"
+      },
       "devDependencies": {
         "@11ty/eleventy": "^1.0.2",
         "@babel/core": "^7.20.2",
@@ -8843,6 +8846,20 @@
         "node": ">=10"
       }
     },
+    "node_modules/image-size": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz",
+      "integrity": "sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==",
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/immutable": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
@@ -8942,8 +8959,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "3.0.1",
@@ -14383,6 +14399,14 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "dev": true
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -72,5 +72,8 @@
     ">0%",
     "not dead",
     "not supports es6-module"
-  ]
+  ],
+  "dependencies": {
+    "image-size": "^1.0.2"
+  }
 }

--- a/src/pages/cats/index.njk
+++ b/src/pages/cats/index.njk
@@ -14,7 +14,7 @@ layout: layout.njk
   fuzzy belly", or "The brothers cuddling in an adorable way".
 </p>
 
-<div class="cmp-pictures-of-cats__grid">
+<div class="cmp-pictures-of-cats__grid" style="--row-count: {{ global.catPictureRows }}">
   {% from 'macros/cat-picture.njk' import catPicture %}
   {% for image in global.picturesOfCats %}
     {{ catPicture(image, loop.index) }}

--- a/src/pages/cats/index.njk
+++ b/src/pages/cats/index.njk
@@ -16,7 +16,7 @@ layout: layout.njk
 
 <div class="cmp-pictures-of-cats__grid">
   {% from 'macros/cat-picture.njk' import catPicture %}
-  {% for image in global.picturesOfCats | reverse %}
+  {% for image in global.picturesOfCats %}
     {{ catPicture(image, loop.index) }}
   {% endfor %}
 </div>

--- a/src/pages/index.njk
+++ b/src/pages/index.njk
@@ -74,7 +74,7 @@ layout: layout.njk
     <h2>Recent Pictures of Cats</h2>
     <div class="cmp-pictures-of-cats__grid">
       {% from 'macros/cat-picture.njk' import catPicture %}
-      {% for image in global.picturesOfCats | reverse %}
+      {% for image in global.picturesOfCats %}
         {% if loop.index <= 2 %}
           {{ catPicture(image, loop.index) }}
         {% endif %}

--- a/src/partials/macros/cat-picture.njk
+++ b/src/partials/macros/cat-picture.njk
@@ -1,5 +1,5 @@
 {% macro catPicture(image, index) %}
-<div>
+<div class="cmp-pictures-of-cats__cell" style="--row-start: {{ image.rowStart }}; --row-span: {{ image.rowSpan }}">
   <picture>
     <source srcset="/images/cats/avif/{{ image.name.replace('.jpg', '.avif') }}" type="image/avif">
     <source srcset="/images/cats/webp/{{ image.name.replace('.jpg', '.webp') }}" type="image/webp">
@@ -8,8 +8,8 @@
       alt=""
       width="{{ image.width }}"
       height="{{ image.height }}"
+      style="--aspect-ratio: {{ image.aspectRatio }}"
       class="cmp-pictures-of-cats__image"
-      style="--row-start: {{ image.rowStart }}; --row-span: {{ image.rowSpan }}"
       {% if index >= 6 %}loading="lazy"{% endif %}
     >
   </picture>

--- a/src/partials/macros/cat-picture.njk
+++ b/src/partials/macros/cat-picture.njk
@@ -1,9 +1,17 @@
 {% macro catPicture(image, index) %}
 <div>
   <picture>
-    <source srcset="/images/cats/avif/{{ image.replace('.jpg', '.avif') }}" type="image/avif">
-    <source srcset="/images/cats/webp/{{ image.replace('.jpg', '.webp') }}" type="image/webp">
-    <img src="/images/cats/{{ image }}" alt="" class="cmp-pictures-of-cats__image" {% if index >= 6 %}loading="lazy"{% endif %}>
+    <source srcset="/images/cats/avif/{{ image.name.replace('.jpg', '.avif') }}" type="image/avif">
+    <source srcset="/images/cats/webp/{{ image.name.replace('.jpg', '.webp') }}" type="image/webp">
+    <img
+      src="/images/cats/{{ image.name }}"
+      alt=""
+      width="{{ image.width }}"
+      height="{{ image.height }}"
+      class="cmp-pictures-of-cats__image"
+      style="--row-start: {{ image.rowStart }}; --row-span: {{ image.rowSpan }}"
+      {% if index >= 6 %}loading="lazy"{% endif %}
+    >
   </picture>
 </div>
 {% endmacro %}

--- a/src/scss/components/_pictures-of-cats.scss
+++ b/src/scss/components/_pictures-of-cats.scss
@@ -1,15 +1,43 @@
 @use '../tools/functions';
 @use '../tools/mixins';
 
+$bp-two-column: 52rem;
+
 .cmp-pictures-of-cats {
   &__grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
     gap: functions.fluid-size('base');
-    place-items: center;
+    grid-template-columns: 1fr;
 
-    @supports (grid-template-rows: masonry) {
-      grid-template-rows: masonry;
+    @media (min-width: $bp-two-column) {
+      grid-template-columns: 1fr 1fr;
+
+      @supports (grid-template-rows: masonry) {
+        grid-template-rows: masonry;
+      }
+
+      @supports not (grid-template-rows: masonry) {
+        --row-count: auto;
+
+        row-gap: 0;
+        grid-template-rows: repeat(var(--row-count, auto), 10px);
+      }
+    }
+  }
+
+  &__cell {
+    @media (min-width: $bp-two-column) {
+      @supports not (grid-template-rows: masonry) {
+        --row-start: 1;
+        --row-span: auto;
+
+        grid-row: var(--row-start, 1) / span var(--row-span, auto);
+        grid-column: 1 / span 1;
+
+        &:nth-child(2n) {
+          grid-column: 2 / span 1;
+        }
+      }
     }
   }
 
@@ -17,5 +45,14 @@
     @include mixins.img-drop-shadow;
 
     border-radius: functions.fluid-size('nano');
+    width: 100%;
+    height: auto;
+
+    @supports not (grid-template-rows: masonry) {
+      --aspect-ratio: 4 / 3;
+
+      aspect-ratio: var(--aspect-ratio);
+      object-fit: cover;
+    }
   }
 }


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
This work hacks together a masonry layout using image dimensions and grid row placement. It's not perfect, but it doesn't rely on any client-side JS and it looks reasonably good, despite some differences in spacing.

### Validation

<!-- Delete anything irrelevant to this PR -->

- [ ] Visual elements match designs (or look reasonably good if no designs provided)
- [ ] Linters still pass
- [ ] Tests still pass
- [ ] Changes were browser tested, including functionality, accessibility, responsiveness, and design

#### To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Go to `/cats` and make sure it looks good in all major browsers/sizes, including Firefox with `masonry` enabled
<!-- Add additional validation steps here -->
