### PR TITLE
feat: flex images instead of faking masonry

### DIFF
--- a/src/pages/_data/global.js
+++ b/src/pages/_data/global.js
@@ -3,32 +3,6 @@ const fs = require('fs');
 const path = require('path');
 const sizeOf = require('image-size');
 
-const commonAspectRatios = [
-  1 / 1,
-  3 / 2,
-  4 / 3,
-  16 / 9,
-  9 / 16,
-  3 / 4,
-  2 / 3,
-];
-
-const closestAspectRatio = (width, height) => {
-  const rawAspectRatio = width / height;
-  let resultIndex = 0;
-  let difference = Number.POSITIVE_INFINITY;
-
-  commonAspectRatios.forEach((aspectRatio, index) => {
-    const currentDifference = Math.abs(aspectRatio - rawAspectRatio);
-    if (currentDifference < difference) {
-      difference = currentDifference;
-      resultIndex = index;
-    }
-  });
-
-  return commonAspectRatios[resultIndex];
-};
-
 const getImagePaths = () => {
   const directoryPath = path.join(__dirname, '../../public/images/cats');
   const files = fs
@@ -46,27 +20,14 @@ const getImagePaths = () => {
       return 0;
     })
     .map((file) => {
-      const STANDARD_WIDTH = 400;
       const { width, height } = sizeOf(`${directoryPath}/${file.name}`);
-      const aspectRatio = closestAspectRatio(width, height);
-      const adjustedHeight = STANDARD_WIDTH / aspectRatio;
       return {
         name: file.name,
         width,
         height,
-        aspectRatio,
-        rowSpan: Math.ceil(adjustedHeight / 10),
+        aspectRatio: width / height,
       };
     });
-
-  for (let i = 0; i < files.length; i += 1) {
-    const previousInColumn = files[i - 2];
-    if (!previousInColumn) {
-      files[i].rowStart = 1;
-    } else {
-      files[i].rowStart = previousInColumn.rowStart + previousInColumn.rowSpan + 2;
-    }
-  }
 
   return files;
 };

--- a/src/pages/cats/index.njk
+++ b/src/pages/cats/index.njk
@@ -14,7 +14,7 @@ layout: layout.njk
   fuzzy belly", or "The brothers cuddling in an adorable way".
 </p>
 
-<div class="cmp-pictures-of-cats__grid" style="--row-count: {{ global.catPictureRows }}">
+<div class="cmp-pictures-of-cats__grid">
   {% from 'macros/cat-picture.njk' import catPicture %}
   {% for image in global.picturesOfCats %}
     {{ catPicture(image, loop.index) }}

--- a/src/partials/macros/cat-picture.njk
+++ b/src/partials/macros/cat-picture.njk
@@ -1,5 +1,5 @@
 {% macro catPicture(image, index) %}
-<div class="cmp-pictures-of-cats__cell" style="--row-start: {{ image.rowStart }}; --row-span: {{ image.rowSpan }}">
+<div class="cmp-pictures-of-cats__cell" style="--aspect-ratio: {{ image.aspectRatio }}">
   <picture>
     <source srcset="/images/cats/avif/{{ image.name.replace('.jpg', '.avif') }}" type="image/avif">
     <source srcset="/images/cats/webp/{{ image.name.replace('.jpg', '.webp') }}" type="image/webp">
@@ -8,7 +8,6 @@
       alt=""
       width="{{ image.width }}"
       height="{{ image.height }}"
-      style="--aspect-ratio: {{ image.aspectRatio }}"
       class="cmp-pictures-of-cats__image"
       {% if index >= 6 %}loading="lazy"{% endif %}
     >

--- a/src/scss/components/_pictures-of-cats.scss
+++ b/src/scss/components/_pictures-of-cats.scss
@@ -17,10 +17,9 @@ $bp-two-column: 52rem;
       }
 
       @supports not (grid-template-rows: masonry) {
-        --row-count: auto;
-
-        row-gap: 0;
-        grid-template-rows: repeat(var(--row-count, auto), 10px);
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
       }
     }
   }
@@ -28,15 +27,10 @@ $bp-two-column: 52rem;
   &__cell {
     @media (min-width: $bp-two-column) {
       @supports not (grid-template-rows: masonry) {
-        --row-start: 1;
-        --row-span: auto;
+        --aspect-ratio: 1;
 
-        grid-row: var(--row-start, 1) / span var(--row-span, auto);
-        grid-column: 1 / span 1;
-
-        &:nth-child(2n) {
-          grid-column: 2 / span 1;
-        }
+        flex-basis: 17.5rem;
+        flex-grow: max((var(--aspect-ratio) - 1) * 1000, 1);
       }
     }
   }
@@ -47,12 +41,5 @@ $bp-two-column: 52rem;
     border-radius: functions.fluid-size('nano');
     width: 100%;
     height: auto;
-
-    @supports not (grid-template-rows: masonry) {
-      --aspect-ratio: 4 / 3;
-
-      aspect-ratio: var(--aspect-ratio);
-      object-fit: cover;
-    }
   }
 }


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
This goes for a lower-risk, higher performance, flexbox layout instead of jumping through hoops to fake a masonry layout.

### Validation

<!-- Delete anything irrelevant to this PR -->

- [ ] Visual elements match designs (or look reasonably good if no designs provided)
- [ ] Linters still pass
- [ ] Tests still pass
- [ ] Changes were browser tested, including functionality, accessibility, responsiveness, and design

#### To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Visit `/cats` and make sure it looks good in all major browsers at all sizes
<!-- Add additional validation steps here -->
