### PR TITLE
feat: reorder projects

### DIFF
--- a/src/pages/_data/global.js
+++ b/src/pages/_data/global.js
@@ -44,7 +44,7 @@ const projects = [
     siteLink: 'https://cashcache.io/',
     description: 'This is how I keep track of what I spend my money on. Why use a popular budgeting app when you can build your own, right?',
     startDate: '2020-12-21',
-    classification: 'Side Projects',
+    classification: 'Side Project',
     roles: ['Individual Contributor'],
   },
   {
@@ -53,7 +53,7 @@ const projects = [
     siteLink: 'https://rpg-spacedoor.netlify.app/',
     description: "A totally homebrewed RPG system for a sci-fi adventure setting. We could call this version 3, and there's very likely to be a version 4 within a year.",
     startDate: '2022-03-13',
-    classification: 'Side Projects',
+    classification: 'Side Project',
     roles: ['Individual Contributor'],
   },
   {
@@ -62,7 +62,7 @@ const projects = [
     siteLink: 'https://fellowship-availability.netlify.app/',
     description: "One does not simply walk into Mordor without checking everyone's schedules first.",
     startDate: '2022-04-12',
-    classification: 'Apprenticeship Capstone Projects',
+    classification: 'Apprenticeship Capstone Project',
     roles: ['Tech Lead'],
   },
   {
@@ -71,7 +71,7 @@ const projects = [
     siteLink: 'https://accessible-components-cheatsheet.netlify.app/',
     description: 'Building things accessibly is hard, so why not make it a little easier?',
     startDate: '2022-09-29',
-    classification: 'Apprenticeship Capstone Projects',
+    classification: 'Apprenticeship Capstone Project',
     roles: ['Tech Lead', 'Product Owner'],
   },
   {
@@ -80,28 +80,28 @@ const projects = [
     siteLink: 'https://sparkbox.com/foundry/series/building_an_eleventy_starter_template',
     description: 'How do you set up a project for success? Using Eleventy as an example, this Foundry series explores common architectural decisions that need to be made when starting a project.',
     startDate: '2022-03-22',
-    classification: 'Side Projects',
+    classification: 'Side Project',
     roles: ['Individual Contributor'],
   },
   {
     name: 'Unnamed Client Project',
     description: 'Building out new versions of their home page, search features, and product/quote pages, among other things.',
     startDate: '2021-04-19',
-    classification: 'Client Projects',
+    classification: 'Client Project',
     roles: ['Individual Contributor', 'Tech Lead'],
   },
   {
     name: 'Mysterious UI Component Library',
     description: 'Built a handful of components for their design system, most notably the checkbox and radio group form components, as well as supporting color themes.',
     startDate: '2022-05-16',
-    classification: 'Client Projects',
+    classification: 'Client Project',
     roles: ['Individual Contributor', 'Tech Lead'],
   },
   {
     name: 'Secretive CMS Migration',
     description: 'Helped with the migration of thousands of pages from their old CMS, Drupal 7, to their new one, Contentful. This involved content modeling, building new components, and lots of scripting.',
     startDate: '2022-08-01',
-    classification: 'Client Projects',
+    classification: 'Client Project',
     roles: ['Individual Contributor', 'Feature Lead'],
   },
 ].sort((a, b) => {
@@ -116,15 +116,6 @@ const projects = [
   return 0;
 });
 
-const breakdown = projects
-  .reduce((acc, project) => ({
-    ...acc,
-    [project.classification]: [
-      ...(acc[project.classification] ?? []),
-      project,
-    ],
-  }), {});
-
 module.exports = {
   // generate a random string for service worker versioning, such as "36f4-1234-8c7a"
   random() {
@@ -136,8 +127,8 @@ module.exports = {
   year() {
     return new Date().getFullYear();
   },
+  projects,
   recentProjects: projects.slice(0, 4),
-  breakdown: Object.entries(breakdown),
   picturesOfCats: getImagePaths(),
   catPictureRows,
 };

--- a/src/pages/_data/global.js
+++ b/src/pages/_data/global.js
@@ -104,6 +104,15 @@ const projects = [
     classification: 'Client Project',
     roles: ['Individual Contributor', 'Feature Lead'],
   },
+  {
+    name: 'dustinwhisman.com',
+    repoLink: 'http://github.com/dustinwhisman/dustinwhisman.com',
+    siteLink: '/',
+    description: "Hey, that's what this is! You're looking at it right now!",
+    startDate: '2022-11-12',
+    classification: 'Side Project',
+    roles: ['Individual Contributor'],
+  },
 ].sort((a, b) => {
   if (a.startDate < b.startDate) {
     return 1;

--- a/src/pages/index.njk
+++ b/src/pages/index.njk
@@ -36,22 +36,10 @@ layout: layout.njk
   <div class="cmp-stack">
     <h2>Recent Projects</h2>
     <ul class="cmp-project__list">
+      {% from 'macros/project-card.njk' import projectCard %}
       {% for project in global.recentProjects %}
         <li>
-          <article class="cmp-project__card">
-            <h3 class="cmp-project__heading">
-              {% if project.siteLink %}
-                <a href="{{ project.siteLink }}">{{ project.name }}</a>
-              {% else %}
-                {{ project.name }}
-              {% endif %}
-            </h3>
-            <ul class="cmp-badge__list">
-              {% for role in project.roles %}
-                <li class="cmp-badge">{{ role }}</li>
-              {% endfor %}
-            </ul>
-          </article>
+          {{ projectCard(project) }}
         </li>
       {% endfor %}
     </ul>
@@ -61,7 +49,7 @@ layout: layout.njk
     <h2>Recent Writing</h2>
     <ul class="cmp-article-listing__list">
       {% for article in collections.writing | reverse %}
-        {% if loop.index <= 3 %}
+        {% if loop.index <= 5 %}
           <li>
             <a href="{{ article.url }}" class="cmp-article-listing__link">{{ article.data.articleTitle }}</a>
             <span>
@@ -81,7 +69,7 @@ layout: layout.njk
     <div class="cmp-pictures-of-cats__grid">
       {% from 'macros/cat-picture.njk' import catPicture %}
       {% for image in global.picturesOfCats %}
-        {% if loop.index <= 2 %}
+        {% if loop.index <= 4 %}
           {{ catPicture(image, loop.index) }}
         {% endif %}
       {% endfor %}

--- a/src/pages/projects/index.njk
+++ b/src/pages/projects/index.njk
@@ -13,34 +13,32 @@ layout: layout.njk
   logistics applications…
 </p>
 
-{% for projectType in global.breakdown %}
-  <div>
-    <h2 class="cmp-project__group-heading">{{ projectType[0] }}</h2>
-    <ul class="cmp-project__list">
-      {% for project in projectType[1] %}
-        <li>
-          <article class="cmp-project__card">
-            <h3 class="cmp-project__heading">
-              {% if project.siteLink %}
-                <a href="{{ project.siteLink }}">{{ project.name }}</a>
-              {% else %}
-                {{ project.name }}
-              {% endif %}
-            </h3>
-            <p>{{ project.description }}</p>
-            {% if project.repoLink %}
-              <p>
-                <a href="{{ project.repoLink }}">View Source</a>
-              </p>
-            {% endif %}
-            <ul class="cmp-badge__list">
-              {% for role in project.roles %}
-                <li class="cmp-badge">{{ role }}</li>
-              {% endfor %}
-            </ul>
-          </article>
-        </li>
-      {% endfor %}
-    </ul>
-  </div>
-{% endfor %}
+<ul class="cmp-project__list">
+  {% for project in global.projects %}
+    <li>
+      <article class="cmp-project__card">
+        <h3 class="cmp-project__heading">
+          {% if project.siteLink %}
+            <a href="{{ project.siteLink }}">{{ project.name }}</a>
+          {% else %}
+            {{ project.name }}
+          {% endif %}
+        </h3>
+        <p class="cmp-project__type cmp-project__type--{{ project.classification.replace(' ', '-') | lower }}">
+          {{ project.classification }}
+        </p>
+        <p>{{ project.description }}</p>
+        {% if project.repoLink %}
+          <p>
+            <a href="{{ project.repoLink }}">View Source</a>
+          </p>
+        {% endif %}
+        <ul class="cmp-badge__list">
+          {% for role in project.roles %}
+            <li class="cmp-badge">{{ role }}</li>
+          {% endfor %}
+        </ul>
+      </article>
+    </li>
+  {% endfor %}
+</ul>

--- a/src/pages/projects/index.njk
+++ b/src/pages/projects/index.njk
@@ -14,31 +14,10 @@ layout: layout.njk
 </p>
 
 <ul class="cmp-project__list">
+  {% from 'macros/project-card.njk' import projectCard %}
   {% for project in global.projects %}
     <li>
-      <article class="cmp-project__card">
-        <h3 class="cmp-project__heading">
-          {% if project.siteLink %}
-            <a href="{{ project.siteLink }}">{{ project.name }}</a>
-          {% else %}
-            {{ project.name }}
-          {% endif %}
-        </h3>
-        <p class="cmp-project__type cmp-project__type--{{ project.classification.replace(' ', '-') | lower }}">
-          {{ project.classification }}
-        </p>
-        <p>{{ project.description }}</p>
-        {% if project.repoLink %}
-          <p>
-            <a href="{{ project.repoLink }}">View Source</a>
-          </p>
-        {% endif %}
-        <ul class="cmp-badge__list">
-          {% for role in project.roles %}
-            <li class="cmp-badge">{{ role }}</li>
-          {% endfor %}
-        </ul>
-      </article>
+      {{ projectCard(project) }}
     </li>
   {% endfor %}
 </ul>

--- a/src/partials/macros/project-card.njk
+++ b/src/partials/macros/project-card.njk
@@ -7,7 +7,7 @@
       {{ project.name }}
     {% endif %}
   </h3>
-  <p class="cmp-project__type cmp-project__type--{{ project.classification.replace(' ', '-') | lower }}">
+  <p class="cmp-project__type cmp-project__type--{{ project.classification.replaceAll(' ', '-') | lower }}">
     {{ project.classification }}
   </p>
   <p>{{ project.description }}</p>

--- a/src/partials/macros/project-card.njk
+++ b/src/partials/macros/project-card.njk
@@ -1,0 +1,25 @@
+{% macro projectCard(project) %}
+<article class="cmp-project__card">
+  <h3 class="cmp-project__heading">
+    {% if project.siteLink %}
+      <a href="{{ project.siteLink }}">{{ project.name }}</a>
+    {% else %}
+      {{ project.name }}
+    {% endif %}
+  </h3>
+  <p class="cmp-project__type cmp-project__type--{{ project.classification.replace(' ', '-') | lower }}">
+    {{ project.classification }}
+  </p>
+  <p>{{ project.description }}</p>
+  {% if project.repoLink %}
+    <p>
+      <a href="{{ project.repoLink }}">View Source</a>
+    </p>
+  {% endif %}
+  <ul class="cmp-badge__list">
+    {% for role in project.roles %}
+      <li class="cmp-badge">{{ role }}</li>
+    {% endfor %}
+  </ul>
+</article>
+{% endmacro %}

--- a/src/scss/components/_project.scss
+++ b/src/scss/components/_project.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @use '../tools/functions';
 
 .cmp-project {
@@ -13,6 +14,7 @@
     display: flex;
     flex-direction: column;
     gap: functions.fluid-size('base');
+    align-items: flex-start;
   }
 
   &__heading {
@@ -23,5 +25,36 @@
   &__group-heading {
     margin-block-start: functions.fluid-size('giga');
     margin-block-end: functions.fluid-size('kilo');
+  }
+
+  &__type {
+    color: var(--ink);
+    font-size: functions.fluid-size('deci');
+    padding-inline-start: functions.fluid-size('micro');
+    border-inline-start: 0.125em solid var(--ink);
+
+    &--apprenticeship-capstone-project {
+      --ink: #{color.hwb(200deg 10% 50%)};
+
+      @media (prefers-color-scheme: dark) {
+        --ink: #{color.hwb(200deg 50% 10%)};
+      }
+    }
+
+    &--side-project {
+      --ink: #{color.hwb(220deg 0% 50%)};
+
+      @media (prefers-color-scheme: dark) {
+        --ink: #{color.hwb(220deg 50% 0%)};
+      }
+    }
+
+    &--client-project {
+      --ink: #{color.hwb(170deg 0% 60%)};
+
+      @media (prefers-color-scheme: dark) {
+        --ink: #{color.hwb(170deg 50% 10%)};
+      }
+    }
   }
 }


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
This changes the projects page to list projects in reverse chronological order and undoes the grouping. Instead, it opts for visually distinct descriptions of the different project types.

#### To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. View the home page and project pages, ensuring the right order and good visuals
<!-- Add additional validation steps here -->
