### PR TITLE
fix: use border-radius instead of clip-path to preserve drop shadow

### DIFF
--- a/src/scss/components/_it-me.scss
+++ b/src/scss/components/_it-me.scss
@@ -9,7 +9,7 @@
     float: inline-start;
     max-width: min(30vw, 200px);
     height: auto;
-    clip-path: circle(50%);
+    border-radius: 50%;
     shape-outside: circle(50%);
     margin-block-end: functions.fluid-size('micro');
     margin-inline-end: functions.fluid-size('base');


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
The drop shadow was being cut off by clip-path. This changes techniques to make it appear again.

#### To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. View the home page to confirm the drop shadow is visible
<!-- Add additional validation steps here -->
