### PR TITLE
fix: limit focus outlines to keyboard interactions

### DIFF
--- a/src/scss/elements/_a.scss
+++ b/src/scss/elements/_a.scss
@@ -9,6 +9,10 @@ a {
   &:focus {
     outline: 0.125em solid var(--ink);
     outline-offset: 0.25em;
+
+    &:not(:focus-visible) {
+      outline-color: transparent;
+    }
   }
 
   &[aria-current='page'] {

--- a/src/scss/elements/_pre.scss
+++ b/src/scss/elements/_pre.scss
@@ -11,6 +11,10 @@ pre {
   &[tabindex='0']:focus {
     outline: 0.125em solid var(--ink);
     outline-offset: 0.25em;
+
+    &:not(:focus-visible) {
+      outline-color: transparent;
+    }
   }
 
   code {


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
This uses the `:not(:focus-visible)` trick to prevent outlines from showing up when you click on a link, especially for phones.

#### To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Go to the deploy preview on a phone and check that tapping links doesn't show the focus outline, but keyboard interactions still show the outlines
<!-- Add additional validation steps here -->
