### PR TITLE
feat: generate sitemap

### DIFF
--- a/src/pages/service-worker.njk
+++ b/src/pages/service-worker.njk
@@ -1,5 +1,6 @@
 ---
 permalink: '/service-worker.js'
+eleventyExcludeFromCollections: true
 ---
 const VERSION = '{{ global.random() }}';
 {% include "service-worker.js" %}

--- a/src/pages/sitemap.njk
+++ b/src/pages/sitemap.njk
@@ -1,0 +1,13 @@
+---
+permalink: /sitemap.xml
+eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+  {% for page in collections.all %}
+    <url>
+      <loc>{{ site.url }}{{ page.url | url }}</loc>
+      <lastmod>{{ page.date.toISOString() }}</lastmod>
+    </url>
+  {% endfor %}
+</urlset>

--- a/src/public/robots.txt
+++ b/src/public/robots.txt
@@ -1,0 +1,4 @@
+Sitemap: https://dustinwhisman.com/sitemap.xml
+
+User-agent: *
+Disallow:


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
This work does the following:
- excludes `service-worker.js` from collections
- generates a sitemap
- points `robots.txt` at the sitemap

This is all to set the stage for some refactoring so pa11y will check the production site on pushes to `main` instead of running in CI.

#### To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm run build`
4. Check `dist` for `sitemap.xml` and confirm that it lists all the URLs for pages on the site
<!-- Add additional validation steps here -->
