### PR TITLE
fix: pa11y fails to run in CI

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -1,6 +1,9 @@
 name: Monitor
 
 on:
+  pull_request:
+    branches:
+      - "main"
   push:
     branches:
       - "main"

--- a/.pa11yci.json
+++ b/.pa11yci.json
@@ -1,7 +1,7 @@
 {
   "defaults": {
     "runners": [
-      "axe"
+      "htmlcs"
     ]
   }
 }

--- a/.pa11yci.json
+++ b/.pa11yci.json
@@ -1,5 +1,6 @@
 {
   "defaults": {
+    "timeout": 60000,
     "runners": [
       "axe",
       "htmlcs"

--- a/.pa11yci.json
+++ b/.pa11yci.json
@@ -1,9 +1,7 @@
 {
   "defaults": {
-    "timeout": 60000,
     "runners": [
-      "axe",
-      "htmlcs"
+      "axe"
     ]
   }
 }


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
This work is for debugging and fixing issues with pa11y in CI (runs locally just fine, but not in GH Actions).

#### To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
<!-- Add additional validation steps here -->
