### PR TITLE
refactor: adjust heading levels

### DIFF
--- a/src/pages/projects/index.njk
+++ b/src/pages/projects/index.njk
@@ -17,11 +17,13 @@ layout: layout.njk
   <a href="#role-descriptions">Description of roles</a>
 </p>
 
+<h2 class="util-visually-hidden">List of projects, from 2021 to now</h2>
+
 <ul class="cmp-project__list">
   {% from 'macros/project-card.njk' import projectCard %}
   {% for project in global.projects %}
     <li>
-      {{ projectCard(project, 'h2') }}
+      {{ projectCard(project, 'h3') }}
     </li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
Rather than project names at the same heading level as the role description heading, this adds a visually hidden heading at the h2 level so that project names can all be h3s.

#### To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Go to `/projects` and check that the heading levels make sense
<!-- Add additional validation steps here -->
