### PR TITLE
test: support environment variable for base url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# change if you're running on a different port
+BASE_URL=http://localhost:8080

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   check-accessibility:
     runs-on: ubuntu-latest
+    env:
+      BASE_URL: ${{ secrets.BASE_URL }}
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js

--- a/README.md
+++ b/README.md
@@ -62,4 +62,12 @@ npm run images:clean
 
 To run Cypress tests locally, you will need to create a `.env` file. Use `.env.example` as a starting point for filling in the variables you need. `BASE_URL` should point to where the site is running, typically `http://localhost:8080`, but you can point it at the production site or a deploy preview for some manual testing.
 
-For local testing, you will need to have the site running already (`npm start`), then in a different terminal, you can run `npm run test:e2e` to run the Cypress tests.
+For local testing, you will need to have the site running already (`npm start`), then in a different terminal, you can run one of these commands to run Cypress.
+
+```sh
+# open Cypress and watch the tests as they happen
+npm run test:open
+
+# run Cypress in CI mode
+npm run test:e2e
+```

--- a/README.md
+++ b/README.md
@@ -57,3 +57,9 @@ npm run images:avif
 # remove all jpg images from the `pictures-of-cats` folder
 npm run images:clean
 ```
+
+## Cypress Testing
+
+To run Cypress tests locally, you will need to create a `.env` file. Use `.env.example` as a starting point for filling in the variables you need. `BASE_URL` should point to where the site is running, typically `http://localhost:8080`, but you can point it at the production site or a deploy preview for some manual testing.
+
+For local testing, you will need to have the site running already (`npm start`), then in a different terminal, you can run `npm run test:e2e` to run the Cypress tests.

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,8 +1,11 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+// eslint-disable-next-line import/no-extraneous-dependencies
+require('dotenv').config();
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { defineConfig } = require('cypress');
 
 const sitemapLocations = async () => {
-  const res = await fetch('https://dustinwhisman.com/sitemap.xml', {
+  const res = await fetch(`${process.env.BASE_URL}/sitemap.xml`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/xml',
@@ -17,6 +20,7 @@ const sitemapLocations = async () => {
 
 module.exports = defineConfig({
   e2e: {
+    baseUrl: process.env.BASE_URL,
     chromeWebSecurity: false,
     setupNodeEvents: async (on, config) => {
       on('task', {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint:js": "eslint . --ext .js,.ts",
     "test": "jest",
     "test:e2e": "cypress run --e2e",
+    "test:open": "cypress open --e2e",
     "update-deps": "ncu -u",
     "postupdate-deps": "npm install",
     "optimize-images": "run-s images:jpg images:webp images:avif images:clean",

--- a/src/pages/_data/processEnv.js
+++ b/src/pages/_data/processEnv.js
@@ -1,0 +1,6 @@
+// eslint-disable-next-line import/no-extraneous-dependencies, @typescript-eslint/no-var-requires
+require('dotenv').config();
+
+module.exports = {
+  BASE_URL: process.env.BASE_URL,
+};

--- a/src/pages/sitemap.njk
+++ b/src/pages/sitemap.njk
@@ -6,7 +6,7 @@ eleventyExcludeFromCollections: true
 <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
   {% for page in collections.all %}
     <url>
-      <loc>https://dustinwhisman.com{{ page.url | url }}</loc>
+      <loc>{{ processEnv.BASE_URL }}{{ page.url | url }}</loc>
       <lastmod>{{ page.date.toISOString() }}</lastmod>
     </url>
   {% endfor %}


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
This work allows Cypress to run tests against whatever base URL is provided, depending on environment. That `BASE_URL` variable is also used for the sitemap.

#### To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Add a `.env` file with `BASE_URL=http://localhost:8080`
4. Run `npm run build`
5. Check `dist/sitemap.xml` to make sure the locations reference `localhost:8080`
6. Run `npm run test:e2e` and make sure they run against localhost
<!-- Add additional validation steps here -->
