### PR TITLE
fix: update theme color to match dark mode background color

### DIFF
--- a/src/partials/layout.njk
+++ b/src/partials/layout.njk
@@ -18,7 +18,7 @@
 
   <link href="https://api.fontshare.com/v2/css?f[]=supreme@400&f[]=recia@500&display=swap" rel="stylesheet">
 
-  <meta name="theme-color" content="#f8f8f8">
+  <meta name="theme-color" content="#1a1a1a">
   <link rel="stylesheet" href="/styles.css">
 </head>
 

--- a/src/public/manifest.json
+++ b/src/public/manifest.json
@@ -20,9 +20,9 @@
     }
   ],
   "start_url": "/",
-  "background_color": "#f8f8f8",
+  "background_color": "#1a1a1a",
   "display": "standalone",
   "scope": "/",
-  "theme_color": "#f8f8f8",
+  "theme_color": "#1a1a1a",
   "description": "Dustin Whisman's very own personal website. How indie, how 2006."
 }

--- a/src/public/manifest.json
+++ b/src/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "short_name": "d.w.",
+  "short_name": "Dustin Whisman",
   "name": "dustinwhisman.com",
   "icons": [
     {


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
This updates the theme color to be the same dark gray used for the dark mode background color

#### To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Go to the deploy preview on a phone
3. Install the site as a PWA
4. Open the site from the new icon on your home screen
5. Confirm that the status bar is dark gray instead of almost white
<!-- Add additional validation steps here -->
