### PR TITLE
fix: access post descriptions correctly for RSS feed

### DIFF
--- a/src/pages/feed.njk
+++ b/src/pages/feed.njk
@@ -26,7 +26,7 @@
     <item>
       <title>{{ post.data.articleTitle }}</title>
       <link>{{ absolutePostUrl }}</link>
-      <description>{{ post.description }}</description>
+      <description>{{ post.data.description }}</description>
       <pubDate>{{ post.date.toUTCString() }}</pubDate>
       <dc:creator>{{ metadata.author.name }}</dc:creator>
       <guid>{{ absolutePostUrl }}</guid>


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
This fixes an issue that was causing descriptions to be blank in the RSS feed.

#### To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Copy the contents of `dist/feed.xml` and paste it into the [RSS feed validator](https://validator.w3.org/feed/#validate_by_input), confirming that it is valid and the descriptions aren't empty
<!-- Add additional validation steps here -->
