### PR TITLE
feat: create GH Action to create issue when updates are available

### DIFF
--- a/.github/workflows/check-for-updates.yml
+++ b/.github/workflows/check-for-updates.yml
@@ -1,0 +1,25 @@
+name: Check for npm updates
+
+on:
+  schedule:
+    - cron: '0 13 * * 6'
+
+jobs:
+  check-for-updates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+      - name: install npm dependencies
+        run: npm ci
+      - name: Check for updates
+        run: npx npm-check-updates -u > updates.txt && git diff package.json | grep -q '^[+-]'
+      - name: Create an issue if there are updates
+        run: |
+          if [ $? -eq 0 ]; then
+            gh issue create -t "Updates available for npm packages" -b $(cat updates.txt) -a ${{secrets.GH_PAT}}
+          fi


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
This is experimental. The idea is to run a cron job to check for npm updates once per week and create a GH issue if any are found. If this fails to do anything, that should be okay, since removing it is quick and easy.

#### To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Run `npx npm-check-updates -u > updates.txt && git diff package.json | grep -q '^[+-]'`
3. Confirm that `updates.txt` is created with the output of `npm-check-updates`
4. If there are no updates available, `updates.txt` should say so and there should be no changes to `package.json`
5. If updates are available, `updates.txt` should say so and there will be a diff for `package.json`
<!-- Add additional validation steps here -->
