### PR TITLE
chore: update npm dependencies

### DIFF
--- a/.github/workflows/check-for-updates.yml
+++ b/.github/workflows/check-for-updates.yml
@@ -1,12 +1,15 @@
 name: Check for npm updates
 
 on:
-  schedule:
-    - cron: '0 13 * * 6'
+  pull_request:
+  # schedule:
+  #   - cron: '0 13 * * 6'
 
 jobs:
   check-for-updates:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{secrets.GH_PAT}}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -17,9 +20,21 @@ jobs:
       - name: install npm dependencies
         run: npm ci
       - name: Check for updates
-        run: npx npm-check-updates -u > updates.txt && git diff package.json | grep -q '^[+-]'
-      - name: Create an issue if there are updates
+        run: npx npm-check-updates -u > updates.txt && git diff package.json | grep '^[+-]'
+      - name: Create a pull request if there are updates
         run: |
           if [ $? -eq 0 ]; then
-            gh issue create -t "Updates available for npm packages" -b $(cat updates.txt) -a ${{secrets.GH_PAT}}
+            git config --global user.email "${{secrets.GH_EMAIL}}"
+            git config --global user.name "${{secrets.GH_NAME}}"
+
+            git checkout -b feat--update-deps-$(date +'%Y-%m-%d')
+            npm install
+            git add package.json package-lock.json
+            git commit -m "chore: update npm dependencies"
+            git push --set-upstream origin feat--update-deps-$(date +'%Y-%m-%d')
+
+            updates=$(sed '1,2d;$d' updates.txt)
+            echo -e "### Description\n\nThis updates the following npm packages to their latest versions.\n\n$updates\n\n#### To Validate\n\n1. Make sure all PR Checks have passed\n2. Check the deploy preview to make sure nothing is obviously broken\n3. Check the changelogs of affected packages to make sure there are no breaking changes to account for" > pr-body.txt
+
+            gh pr create --title "chore: update npm dependencies" --body "$(cat pr-body.txt)"
           fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "license": "CC BY 4.0",
       "dependencies": {
-        "axe-core": "^4.6.2",
-        "cypress": "^12.3.0",
+        "axe-core": "^4.6.3",
+        "cypress": "^12.4.1",
         "cypress-axe": "^1.3.0",
         "cypress-each": "^1.13.1",
         "highlight.js": "^11.7.0",
@@ -26,7 +26,7 @@
         "eslint-config-prettier": "^8.6.0",
         "husky": "^8.0.3",
         "lint-staged": "^13.1.0",
-        "npm-check-updates": "^16.6.2",
+        "npm-check-updates": "^16.6.3",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.21",
         "postcss-cli": "^10.1.0",
@@ -1100,9 +1100,9 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "node_modules/axe-core": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.2.tgz",
-      "integrity": "sha512-b1WlTV8+XKLj9gZy2DZXgQiyDp9xkkoe2a6U6UbYccScq2wgH/YwCeI2/Jq2mgo0HzQxqJOjWZBLeA/mqsk5Mg==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.3.tgz",
+      "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==",
       "engines": {
         "node": ">=4"
       }
@@ -2280,9 +2280,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
-      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
+      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^2.88.10",
@@ -7004,9 +7004,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "16.6.2",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.6.2.tgz",
-      "integrity": "sha512-J/L90a+NDDWscBQGKIsPKer+qbQEQRJDpK+BPsVZf9YWDN5DCAMicPqRb+Emnxfi8QboiNmvDJWRUFFWRQzDMg==",
+      "version": "16.6.3",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.6.3.tgz",
+      "integrity": "sha512-EKhsCbBcVrPlYKzaYQtRhGv9fxpexwROcvl5HebCUNpiCSlOWrzaJvrMlwi9i9GCyJCnH+YAeBPYdqnArA390A==",
       "dev": true,
       "dependencies": {
         "chalk": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-config-prettier": "^8.6.0",
     "husky": "^8.0.3",
     "lint-staged": "^13.1.0",
-    "npm-check-updates": "^16.6.2",
+    "npm-check-updates": "^16.6.3",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.21",
     "postcss-cli": "^10.1.0",
@@ -58,8 +58,8 @@
     "not supports es6-module"
   ],
   "dependencies": {
-    "axe-core": "^4.6.2",
-    "cypress": "^12.3.0",
+    "axe-core": "^4.6.3",
+    "cypress": "^12.4.1",
     "cypress-axe": "^1.3.0",
     "cypress-each": "^1.13.1",
     "highlight.js": "^11.7.0",


### PR DESCRIPTION
### Description

This updates the following npm packages to their latest versions.

 axe-core            ^4.6.2  →   ^4.6.3
 cypress            ^12.3.0  →  ^12.4.1
 npm-check-updates  ^16.6.2  →  ^16.6.3

#### To Validate

1. Make sure all PR Checks have passed
2. Check the deploy preview to make sure nothing is obviously broken
3. Check the changelogs of affected packages to make sure there are no breaking changes to account for