### PR TITLE
feat: remove third party fonts

### DIFF
--- a/src/css/elements/_headings.css
+++ b/src/css/elements/_headings.css
@@ -1,23 +1,23 @@
 h1 {
   font-size: var(--size-s4);
-  font-family: var(--sans);
+  font-family: var(--serif);
   margin-bottom: 0.65em;
 }
 
 h2 {
   font-size: var(--size-s3);
-  font-family: var(--sans);
+  font-family: var(--serif);
   margin-block-start: 0.65em;
 }
 
 h3 {
   font-size: var(--size-s2);
-  font-family: var(--sans);
+  font-family: var(--serif);
   margin-block-start: 0.65em;
 }
 
 h4 {
   font-size: var(--size-s1);
-  font-family: var(--sans);
+  font-family: var(--serif);
   margin-block-start: 0.65em;
 }

--- a/src/css/elements/_root.css
+++ b/src/css/elements/_root.css
@@ -5,10 +5,10 @@
   --terminal: hwb(180deg 85% 5%);
 
   /* font families */
-  --serif: 'Supreme', 'Iowan Old Style', 'Apple Garamond', 'Baskerville',
-    'Times New Roman', 'Droid Serif', 'Times', 'Source Serif Pro', serif,
-    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
-  --sans: 'Recia', -apple-system, 'BlinkMacSystemFont', 'avenir next', 'avenir',
+  --serif: 'Iowan Old Style', 'Apple Garamond', 'Baskerville', 'Times New Roman',
+    'Droid Serif', 'Times', 'Source Serif Pro', serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol';
+  --sans: -apple-system, 'BlinkMacSystemFont', 'avenir next', 'avenir',
     'segoe ui', 'helvetica neue', 'helvetica', 'Ubuntu', 'roboto', 'noto',
     'arial', sans-serif;
   --mono: ui-monospace, menlo, monaco, 'Cascadia Mono', 'Segoe UI Mono',
@@ -28,7 +28,7 @@
   --size-s-4: clamp(0.5rem, 0.4rem + 0.33vw, 0.6rem);
   --size-s-5: clamp(0.4rem, 0.33rem + 0.25vw, 0.5rem);
 
-  font-family: var(--serif);
+  font-family: var(--sans);
   color-scheme: light dark;
   background-color: var(--paper);
   color: var(--ink);

--- a/src/partials/layout.njk
+++ b/src/partials/layout.njk
@@ -16,8 +16,6 @@
   <link rel="apple-touch-icon" href="/maskable_icon.png">
   <link rel="manifest" href="/manifest.json">
 
-  <link href="https://api.fontshare.com/v2/css?f[]=supreme@400&f[]=recia@500&display=swap" rel="stylesheet">
-
   <meta name="color-scheme" content="light dark">
   <meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)">
   <meta name="theme-color" content="#f2f2f2" media="(prefers-color-scheme: light)">


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
This work removes the third party fonts, instead opting for the fallbacks that are already in the font-stack. It also fixes a mixup between sans/serif fonts. Oops.

#### To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Check a smattering of pages and make sure the typography is acceptable
5. Run Lighthouse/webpagetest audits against the deploy preview to check that performance is better than the live site
<!-- Add additional validation steps here -->
