### PR TITLE
chore: update npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "CC BY 4.0",
       "dependencies": {
         "axe-core": "^4.6.3",
-        "cypress": "^12.4.1",
+        "cypress": "^12.5.1",
         "cypress-axe": "^1.3.0",
         "cypress-each": "^1.13.1",
         "highlight.js": "^11.7.0",
@@ -22,7 +22,7 @@
         "check-node-version": "^4.2.1",
         "cssnano": "^5.1.14",
         "dotenv": "^16.0.3",
-        "eslint": "^8.32.0",
+        "eslint": "^8.33.0",
         "eslint-config-prettier": "^8.6.0",
         "husky": "^8.0.3",
         "lint-staged": "^13.1.0",
@@ -2280,9 +2280,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.4.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.4.1.tgz",
-      "integrity": "sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==",
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.5.1.tgz",
+      "integrity": "sha512-ZmCmJ3lsyeOpBfh410m5+AO2CO1AxAzFBt7k6/uVbNcrNZje1vdiwYTpj2ksPKg9mjr9lR6V8tmlDNMvr4H/YQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^2.88.10",
@@ -2973,9 +2973,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
-      "integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.33.0.tgz",
+      "integrity": "sha512-WjOpFQgKK8VrCnAtl8We0SUOy/oVZ5NHykyMiagV1M9r8IFpIJX7DduK6n1mpfhlG7T1NLWm2SuD8QB7KFySaA==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "check-node-version": "^4.2.1",
     "cssnano": "^5.1.14",
     "dotenv": "^16.0.3",
-    "eslint": "^8.32.0",
+    "eslint": "^8.33.0",
     "eslint-config-prettier": "^8.6.0",
     "husky": "^8.0.3",
     "lint-staged": "^13.1.0",
@@ -59,7 +59,7 @@
   ],
   "dependencies": {
     "axe-core": "^4.6.3",
-    "cypress": "^12.4.1",
+    "cypress": "^12.5.1",
     "cypress-axe": "^1.3.0",
     "cypress-each": "^1.13.1",
     "highlight.js": "^11.7.0",


### PR DESCRIPTION
### Description

This updates the following npm packages to their latest versions.

 cypress  ^12.4.1  →  ^12.5.1
 eslint   ^8.32.0  →  ^8.33.0

#### To Validate

1. Make sure all PR Checks have passed
2. Check the deploy preview to make sure nothing is obviously broken
3. Check the changelogs of affected packages to make sure there are no breaking changes to account for