### PR TITLE
fix: add trailing slashes to internal links

### DIFF
--- a/src/pages/writing/in-search-of-the-perfect-build-process.md
+++ b/src/pages/writing/in-search-of-the-perfect-build-process.md
@@ -17,7 +17,7 @@ tags:
   </time>
 </p>
 
-If you've taken the time to read my [series on creating an Eleventy starter template](/writing/eleventy-starter-template), you may have the (correct) impression that I think about build processes quite a bit. One of the goals of that project and the resulting [starter template](https://github.com/dustin-jw/eleventy-starter) was to have something I could use to quickly get a new site up and running with very little effort.
+If you've taken the time to read my [series on creating an Eleventy starter template](/writing/eleventy-starter-template/), you may have the (correct) impression that I think about build processes quite a bit. One of the goals of that project and the resulting [starter template](https://github.com/dustin-jw/eleventy-starter) was to have something I could use to quickly get a new site up and running with very little effort.
 
 I think I achieved that goal reasonably well, considering that I used it to create this very site–a quick look back at the commit history shows that my first commit was on a Saturday morning, and by Sunday afternoon, the first version of the site was live. However, I also built that starter template to cover a wide range of scenarios that might not apply to every project, including this site, so I'm going to walk through some of the changes I've made recently to clean up the build process.
 

--- a/src/pages/writing/index.njk
+++ b/src/pages/writing/index.njk
@@ -10,13 +10,13 @@ layout: layout.njk
 
 <ul class="cmp-article-listing__list">
   <li>
-    <a href="/writing/learning-in-public" class="cmp-article-listing__link">Learning in Public</a>
+    <a href="/writing/learning-in-public/" class="cmp-article-listing__link">Learning in Public</a>
   </li>
   <li>
-    <a href="/writing/learning-in-public/web-accessibility-specialist-certification" class="cmp-article-listing__link">Web Accessibility Specialist (WAS) Certification Notes</a>
+    <a href="/writing/learning-in-public/web-accessibility-specialist-certification/" class="cmp-article-listing__link">Web Accessibility Specialist (WAS) Certification Notes</a>
   </li>
   <li>
-    <a href="/writing/eleventy-starter-template" class="cmp-article-listing__link">Eleventy Starter Template Series</a>
+    <a href="/writing/eleventy-starter-template/" class="cmp-article-listing__link">Eleventy Starter Template Series</a>
   </li>
 </ul>
 

--- a/src/partials/layout.njk
+++ b/src/partials/layout.njk
@@ -34,13 +34,13 @@
             <a href="/" {% if page.url === '/' %}aria-current="page"{% endif %}>Home</a>
           </li>
           <li>
-            <a href="/projects" {% if page.url === '/projects/' %}aria-current="page"{% endif %}>Projects</a>
+            <a href="/projects/" {% if page.url === '/projects/' %}aria-current="page"{% endif %}>Projects</a>
           </li>
           <li>
-            <a href="/writing" {% if page.url === '/writing/' %}aria-current="page"{% endif %}>Writing</a>
+            <a href="/writing/" {% if page.url === '/writing/' %}aria-current="page"{% endif %}>Writing</a>
           </li>
           <li>
-            <a href="/cats" {% if page.url === '/cats/' %}aria-current="page"{% endif %}>Pictures of Cats</a>
+            <a href="/cats/" {% if page.url === '/cats/' %}aria-current="page"{% endif %}>Pictures of Cats</a>
           </li>
         </ul>
       </nav>
@@ -72,7 +72,7 @@
           <a href="/feed.xml">RSS Feed</a>
         </li>
         <li>
-          <a href="/contact-me">Contact Me</a>
+          <a href="/contact-me/">Contact Me</a>
         </li>
         <li>
           <a href="https://creativecommons.org/licenses/by/4.0/">Content License</a>


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
This should prevent unnecessary 301 redirects when people click links on the site.

#### To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Click the affected links, making sure the documents return 200 statuses in the deploy preview
<!-- Add additional validation steps here -->
