### PR TITLE
feat: organize cat pictures by month

### DIFF
--- a/src/css/components/_navigation.css
+++ b/src/css/components/_navigation.css
@@ -6,3 +6,7 @@
   padding-inline: 0;
   font-size: var(--size-s0);
 }
+
+.cmp-navigation--basic-pagination {
+  justify-content: space-between;
+}

--- a/src/pages/_data/global.js
+++ b/src/pages/_data/global.js
@@ -33,9 +33,23 @@ const getImagePaths = () => {
 };
 
 const picturesOfCats = getImagePaths();
-const catPictureRows = Math.max(
-  ...picturesOfCats.map((picture) => picture.rowStart + picture.rowSpan),
-);
+const catsByMonth = picturesOfCats.reduce((monthsObj, picture) => {
+  const date = picture.name.substring(4, 12);
+  const monthSlug = `${date.slice(0, 4)}-${date.slice(4, 6)}`;
+  const monthDisplayName = new Date(monthSlug).toLocaleDateString(undefined, {
+    timeZone: 'UTC',
+    year: 'numeric',
+    month: 'long',
+  });
+
+  return {
+    ...monthsObj,
+    [monthSlug]: {
+      name: monthDisplayName,
+      pictures: [...(monthsObj[monthSlug]?.pictures ?? []), picture],
+    },
+  };
+}, {});
 
 const projects = [
   {
@@ -148,5 +162,5 @@ module.exports = {
   projects,
   recentProjects: projects.slice(0, 4),
   picturesOfCats: getImagePaths(),
-  catPictureRows,
+  catsByMonth,
 };

--- a/src/pages/cats/index.njk
+++ b/src/pages/cats/index.njk
@@ -14,9 +14,26 @@ layout: layout.njk
   fuzzy belly", or "The brothers cuddling in an adorable way".
 </p>
 
-<div class="cmp-pictures-of-cats__grid">
+{% from 'macros/cat-picture.njk' import catPicture %}
+{% for month, monthData in global.catsByMonth %}
+  {% if loop.index <= 3 %}
+    <h2>{{ monthData.name }}</h2>
+    <div class="cmp-pictures-of-cats__grid">
+      {% for image in monthData.pictures %}
+        {{ catPicture(image, loop.index, 6) }}
+      {% endfor %}
+    </div>
+  {% elseif loop.index === 4 %}
+    <h2>Older Pictures</h2>
+    <p><a href="/cats/{{ month }}/">{{ monthData.name }}</a></p>
+  {% else %}
+    <p><a href="/cats/{{ month }}/">{{ monthData.name }}</a></p>
+  {% endif %}
+{% endfor %}
+
+<!-- <div class="cmp-pictures-of-cats__grid">
   {% from 'macros/cat-picture.njk' import catPicture %}
   {% for image in global.picturesOfCats %}
     {{ catPicture(image, loop.index, 6) }}
   {% endfor %}
-</div>
+</div> -->

--- a/src/pages/cats/index.njk
+++ b/src/pages/cats/index.njk
@@ -15,12 +15,14 @@ layout: layout.njk
 </p>
 
 {% from 'macros/cat-picture.njk' import catPicture %}
+{% set imagesRendered = 0 %}
 {% for month, monthData in global.catsByMonth %}
   {% if loop.index <= 3 %}
     <h2>{{ monthData.name }}</h2>
     <div class="cmp-pictures-of-cats__grid">
       {% for image in monthData.pictures %}
-        {{ catPicture(image, loop.index, 6) }}
+        {% set imagesRendered = imagesRendered + 1 %}
+        {{ catPicture(image, imagesRendered, 4) }}
       {% endfor %}
     </div>
   {% elseif loop.index === 4 %}

--- a/src/pages/cats/index.njk
+++ b/src/pages/cats/index.njk
@@ -32,10 +32,3 @@ layout: layout.njk
     <p><a href="/cats/{{ month }}/">{{ monthData.name }}</a></p>
   {% endif %}
 {% endfor %}
-
-<!-- <div class="cmp-pictures-of-cats__grid">
-  {% from 'macros/cat-picture.njk' import catPicture %}
-  {% for image in global.picturesOfCats %}
-    {{ catPicture(image, loop.index, 6) }}
-  {% endfor %}
-</div> -->

--- a/src/pages/cats/month.njk
+++ b/src/pages/cats/month.njk
@@ -4,24 +4,32 @@ pagination:
   size: 1
   alias: month
 permalink: "cats/{{ month | slug }}/"
-title: "Pictures of Cats | Dustin Whisman"
-description: Look at Goose and Barry! They're so cute, those little monsters.
-layout: layout.njk
 ---
 
-<h1>Pictures of Cats: {{ global.catsByMonth[month].name }}</h1>
+{% extends 'layout.njk' %}
 
-<p class="util-visually-hidden">
-  I do apologize if you can't see the cat pictures. I didn't add alt text to the
-  images because there are a lot of them, and I doubt that descriptions of cats
-  are interesting to read or hear. Most of them would just say "Goose looking
-  concerned about something", "Barry flopped over on his back, exposing his
-  fuzzy belly", or "The brothers cuddling in an adorable way".
-</p>
+{% block titleAndDescription %}
+<title>{{ global.catsByMonth[month].name }} | Pictures of Cats | Dustin Whisman</title>
+<meta name="description" content="Look at these pictures of Goose and Barry from {{ global.catsByMonth[month].name }}! They're so cute, those little monsters.">
+{% endblock %}
 
-<div class="cmp-pictures-of-cats__grid">
-  {% from 'macros/cat-picture.njk' import catPicture %}
-  {% for image in global.catsByMonth[month].pictures %}
-    {{ catPicture(image, loop.index, 6) }}
-  {% endfor %}
-</div>
+{% block content %}
+<article class="cmp-container cmp-stack">
+  <h1>Pictures of Cats: {{ global.catsByMonth[month].name }}</h1>
+
+  <p class="util-visually-hidden">
+    I do apologize if you can't see the cat pictures. I didn't add alt text to the
+    images because there are a lot of them, and I doubt that descriptions of cats
+    are interesting to read or hear. Most of them would just say "Goose looking
+    concerned about something", "Barry flopped over on his back, exposing his
+    fuzzy belly", or "The brothers cuddling in an adorable way".
+  </p>
+
+  <div class="cmp-pictures-of-cats__grid">
+    {% from 'macros/cat-picture.njk' import catPicture %}
+    {% for image in global.catsByMonth[month].pictures %}
+      {{ catPicture(image, loop.index, 6) }}
+    {% endfor %}
+  </div>
+</article>
+{% endblock %}

--- a/src/pages/cats/month.njk
+++ b/src/pages/cats/month.njk
@@ -4,6 +4,7 @@ pagination:
   size: 1
   alias: month
 permalink: "cats/{{ month | slug }}/"
+eleventyExcludeFromCollections: true
 ---
 
 {% extends 'layout.njk' %}

--- a/src/pages/cats/month.njk
+++ b/src/pages/cats/month.njk
@@ -1,0 +1,27 @@
+---
+pagination:
+  data: global.catsByMonth
+  size: 1
+  alias: month
+permalink: "cats/{{ month | slug }}/"
+title: "Pictures of Cats | Dustin Whisman"
+description: Look at Goose and Barry! They're so cute, those little monsters.
+layout: layout.njk
+---
+
+<h1>Pictures of Cats: {{ global.catsByMonth[month].name }}</h1>
+
+<p class="util-visually-hidden">
+  I do apologize if you can't see the cat pictures. I didn't add alt text to the
+  images because there are a lot of them, and I doubt that descriptions of cats
+  are interesting to read or hear. Most of them would just say "Goose looking
+  concerned about something", "Barry flopped over on his back, exposing his
+  fuzzy belly", or "The brothers cuddling in an adorable way".
+</p>
+
+<div class="cmp-pictures-of-cats__grid">
+  {% from 'macros/cat-picture.njk' import catPicture %}
+  {% for image in global.catsByMonth[month].pictures %}
+    {{ catPicture(image, loop.index, 6) }}
+  {% endfor %}
+</div>

--- a/src/pages/cats/month.njk
+++ b/src/pages/cats/month.njk
@@ -31,5 +31,14 @@ permalink: "cats/{{ month | slug }}/"
       {{ catPicture(image, loop.index, 6) }}
     {% endfor %}
   </div>
+
+  <nav class="cmp-navigation cmp-navigation--basic-pagination" aria-label="Picture of cats by month">
+    {% if pagination.href.previous %}
+      <a href="{{ pagination.href.previous }}">Newer pictures</a>
+    {% endif %}
+    {% if pagination.href.next %}
+      <a href="{{ pagination.href.next }}">Older pictures</a>
+    {% endif %}
+  </nav>
 </article>
 {% endblock %}

--- a/src/pages/sitemap.njk
+++ b/src/pages/sitemap.njk
@@ -10,4 +10,9 @@ eleventyExcludeFromCollections: true
       <lastmod>{{ page.date.toISOString() }}</lastmod>
     </url>
   {% endfor %}
+  {% for month, monthData in global.catsByMonth %}
+    <url>
+      <loc>{{ processEnv.BASE_URL }}/cats/{{ month }}/</loc>
+    </url>
+  {% endfor %}
 </urlset>

--- a/src/partials/layout.njk
+++ b/src/partials/layout.njk
@@ -6,8 +6,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
+  {% block titleAndDescription %}
   <title>{{ title }}</title>
   <meta name="description" content="{{ description }}">
+  {% endblock %}
 
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="alternate icon" href="/favicon.png" type="image/png">


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
This addresses some performance issues caused by indiscriminately dumping hundreds of images onto one page. The following changes should make the page weight/DOM size more manageable going forward:

- Organizes cat pictures by month using time info from filenames
- Shows only 3 months of pictures on `/cats`
- Creates pages for each month of cat pictures, including previous/next links
- Supports overriding the title and description (necessary to access the pagination data)
- Updates the sitemap to include the paginated cat pages

#### To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Navigate to each month's page to confirm accuracy/performance
5. Run some Lighthouse/webpagetest audits to see if performance has improved
<!-- Add additional validation steps here -->
