### PR TITLE
refactor: switch back to creating issues rather than PRs for npm updates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 <!-- Add description of work done here -->
 
-#### To Validate
+### To Validate
 
 <!-- Add steps a reviewer should follow to validate your changes -->
 

--- a/.github/workflows/check-for-updates.yml
+++ b/.github/workflows/check-for-updates.yml
@@ -20,20 +20,11 @@ jobs:
         run: npm ci
       - name: Check for updates
         run: npx npm-check-updates -u > updates.txt && git diff package.json | grep '^[+-]'
-      - name: Create a pull request if there are updates
+      - name: Create an issue if there are updates
         run: |
           if [ $? -eq 0 ]; then
-            git config --global user.email "${{secrets.GH_EMAIL}}"
-            git config --global user.name "${{secrets.GH_NAME}}"
-
-            git checkout -b chore--update-deps-$(date +'%Y-%m-%d')
-            npm install
-            git add package.json package-lock.json
-            git commit -m "chore: update npm dependencies"
-            git push --set-upstream origin chore--update-deps-$(date +'%Y-%m-%d')
-
             updates=$(sed '1,2d;$d' updates.txt)
-            echo -e "### Description\n\nThis updates the following npm packages to their latest versions.\n\n$updates\n\n#### To Validate\n\n1. Make sure all PR Checks have passed\n2. Check the deploy preview to make sure nothing is obviously broken\n3. Check the changelogs of affected packages to make sure there are no breaking changes to account for" > pr-body.txt
+            echo -e "### Description\n\nThe following npm packages should be updated to their latest versions.\n\n$updates\n\n" > issue-body.txt
 
-            gh pr create --title "chore: update npm dependencies" --body "$(cat pr-body.txt)"
+            gh issue create -t "Update npm dependencies" -b "$(cat issue-body.txt)" -a ${{ secrets.GH_PAT }}
           fi


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
With the lack of signed commits and the amount of validation that needs to happen anyway, it makes more sense to create issues than PRs automatically for npm updates.

#### To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Check back in a week and see if it worked (if not, that's fine for this purpose)
<!-- Add additional validation steps here -->
