### PR TITLE
fix: give code samples unique accessible names

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -9,18 +9,18 @@ module.exports = function (eleventyConfig) {
     highlight: function (str, lang) {
       if (lang && hljs.getLanguage(lang)) {
         try {
-          return `<pre tabindex="0"><code class="language-${lang}">${
-            hljs.highlight(str, {
-              language: lang,
-              ignoreIllegals: true,
-            }).value
-          }</code></pre>`;
+          return `<pre tabindex="0" role="region" aria-label="Code sample"><code class="language-${lang}">${
+						hljs.highlight(str, {
+							language: lang,
+							ignoreIllegals: true,
+						}).value
+					}</code></pre>`;
         } catch {
           // swallow error, fall through to default case
         }
       }
 
-      return `<pre tabindex="0"><code>${md.utils.escapeHtml(str)}</code></pre>`;
+      return `<pre tabindex="0" role="region" aria-label="Code sample"><code>${md.utils.escapeHtml(str)}</code></pre>`;
     },
   };
 

--- a/pages/global-scripts.njk
+++ b/pages/global-scripts.njk
@@ -3,3 +3,4 @@ permalink: /global-scripts.js
 eleventyExcludeFromCollections: true
 ---
 {% include "js/special-dates.js" %}
+{% include "js/update-code-block-names.js" %}

--- a/src/js/update-code-block-names.js
+++ b/src/js/update-code-block-names.js
@@ -1,0 +1,8 @@
+const updateCodeBlockNames = () => {
+	const codeBlocks = document.querySelectorAll('pre[tabindex="0"]');
+	codeBlocks.forEach((codeBlock, index) => {
+		codeBlock.setAttribute('aria-label', `Code sample ${index + 1}`);
+	});
+};
+
+updateCodeBlockNames();


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
This adds `role="region"` and `aria-label` attributes to code blocks (`pre`) so screen readers can announce them. This still gets flagged by IBM's accessibility checker, but I'm following [guidance from Adrian Roselli](https://adrianroselli.com/2022/06/keyboard-only-scrolling-areas.html), which I'm inclined to believe more than the tooling. The names are somewhat generic, so I may need to circle back and figure out a way to describe the code sample via content.

### To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
<!-- Add additional validation steps here -->
