### PR TITLE
feat: set up CSS tests for bad HTML patterns

### DIFF
--- a/pages/_data/processEnv.js
+++ b/pages/_data/processEnv.js
@@ -3,4 +3,5 @@ require('dotenv').config();
 
 module.exports = {
 	BASE_URL: process.env.BASE_URL,
+	NODE_ENV: process.env.NODE_ENV,
 };

--- a/src/partials/layout.njk
+++ b/src/partials/layout.njk
@@ -9,6 +9,9 @@
 	<title>{{ title }}</title>
 	{% endblock %}
 	<link rel="stylesheet" href="/styles.css">
+	{% if processEnv.NODE_ENV === 'development' %}
+	<link rel="stylesheet" href="/revenge.css">
+	{% endif %}
 	{% block description %}
 	<meta name="description" content="{{ description }}">
 	{% endblock %}

--- a/src/public/revenge.css
+++ b/src/public/revenge.css
@@ -1,0 +1,136 @@
+:root {
+	--error-outline: 0.25rem solid hotpink;
+	--warning-outline: 0.25rem solid goldenrod;
+}
+
+@layer generic, elements, components, utilities, warnings, errors;
+
+@layer warnings {
+	input:not(form input) {
+		--warning-rogue-input: 'This input does not belong to a <form>. Users may benefit from <form> semantics and behaviors';
+
+		outline: var(--warning-outline);
+	}
+
+	select:not(form select) {
+		--warning-rogue-select: 'This select does not belong to a <form>. Users may benefit from <form> semantics and behaviors';
+
+		outline: var(--warning-outline);
+	}
+
+	textarea:not(form textarea) {
+		--warning-rogue-textarea: 'This textarea does not belong to a <form>. Users may benefit from <form> semantics and behaviors';
+
+		outline: var(--warning-outline);
+	}
+
+	figure[aria-label]:not(:has(figcaption)) {
+		--warning-figure-label-not-visible: 'The labeling method used is not visible and only available to assistive software';
+
+		outline: var(--warning-outline);
+	}
+
+	figure[aria-label] figcaption {
+		--warning-overridden-figcaption: 'The figure has a figcaption that is overridden by an ARIA label';
+
+		outline: var(--warning-outline);
+	}
+
+	:is(div > div > div > div > *) {
+		--warning-divitis: "There's a whole lot of nesting going on here. Is it needed to achieve the layout? (it is not)";
+
+		outline: var(--warning-outline);
+	}
+
+	header nav:has(ul > ul) {
+		--warning-nested-navigation: 'You appear to be using tiered/nested navigation in your header. This can be difficult to traverse. Index pages with tables of content are preferable.';
+
+		outline: var(--warning-outline);
+	}
+}
+
+@layer errors {
+	a:not([href]) {
+		--error-no-href: 'The link does not have an href. Did you mean to use a <button>?';
+
+		outline: var(--error-outline);
+	}
+
+	a[href=''] {
+		--error-empty-href: "The link's href is empty. Did you mean to use a <button>?";
+
+		outline: var(--error-outline);
+	}
+
+	a[href$='#'] {
+		--error-empty-hash: "The link's href ends with a fragment to nowhere. Did you mean to use a <button>?";
+
+		outline: var(--error-outline);
+	}
+
+	a[href^='javascript'] {
+		--error-javascript-href: "The link's href appears to call JavaScript rather than navigate to a location. Did you mean to use a <button>?";
+
+		outline: var(--error-outline);
+	}
+
+	a[disabled] {
+		--error-disabled-link: 'The disabled property is not valid on links. Did you mean to use a <button>?';
+
+		outline: var(--error-outline);
+	}
+
+	:is(div, span)[role='button'] {
+		--error-generic-button-role: 'A non-interactive element has been given a button role. Did you mean to use a <button>?';
+
+		outline: var(--error-outline);
+	}
+
+	:is(div, span)[tabindex='0'] {
+		--error-generic-focusable: 'A non-interactive element has been placed in the tab order. Did you mean to use a <button>?';
+
+		outline: var(--error-outline);
+	}
+
+	:is(div, span)[onclick] {
+		--error-generic-clickable: 'A click handler has been added to a non-interactive element. Did you mean to use a <button>?';
+
+		outline: var(--error-outline);
+	}
+
+	label:not(:has(:is(input, output, textarea, select)), [for]) {
+		--error-labeling-nothing: 'This label is not actually labeling anything. Did you mean to wrap it around an input or set a for attribute on it?';
+
+		outline: var(--error-outline);
+	}
+
+	figcaption:not(figure > figcaption) {
+    --error-figcaption-not-child: 'The figcaption is not a direct child of a figure';
+
+		outline: var(--error-outline);
+  }
+
+  figure > figcaption ~ figcaption {
+    --error-multiple-figcaptions: 'There are two figcaptions for one figure';
+
+		outline: var(--error-outline);
+  }
+
+  figcaption:empty {
+    --error-figcaption-empty: 'The figcaption is empty';
+
+		outline: var(--error-outline);
+  }
+
+  figure:not(:is([aria-label], [aria-labelledby]), :has(figcaption)) {
+    --error-no-figure-label: 'The figure is not labeled by any applicable method';
+
+		outline: var(--error-outline);
+  }
+
+	body :not(:is(header, nav, main, aside, footer), :is(header, nav, main, aside, footer) *) {
+		--error-content-outside-landmark: 'You have some content that is not inside a landmark (header, nav, main, aside, or footer)';
+
+		outline: var(--error-outline);
+	}
+}


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
This adds a CSS file for testing for bad HTML patterns. It can be used during development to prevent issues, but it won't be used in staging/production. You can also use it in a bookmarklet to run against other sites.

### To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
<!-- Add additional validation steps here -->
