### PR TITLE
feat: support full text RSS feed

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,6 +1,7 @@
 const hljs = require('highlight.js');
 const markdownIt = require('markdown-it');
 const markdownItAnchor = require('markdown-it-anchor');
+const pluginRSS = require('@11ty/eleventy-plugin-rss');
 
 module.exports = function (eleventyConfig) {
 	eleventyConfig.addPassthroughCopy({ 'src/public': '/' });
@@ -40,6 +41,11 @@ module.exports = function (eleventyConfig) {
 
 	eleventyConfig.setLibrary('md', md);
 	eleventyConfig.addLayoutAlias('default', 'partials/layout.njk');
+	eleventyConfig.addPlugin(pluginRSS, {
+		posthtmlRenderOptions: {
+			closingSingleTag: 'default',
+		},
+	});
 
 	return {
 		dir: {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -26,18 +26,15 @@ module.exports = function (eleventyConfig) {
 		},
 	};
 
-	const md = markdownIt(markdownOptions)
-		.use(markdownItAnchor, {
-			level: 2,
-			permalink: markdownItAnchor.permalink.linkAfterHeader({
-				class: 'cmp-permalink__link',
-				style: 'visually-hidden',
-				assistiveText: (title) => `Permalink: ${title}`,
-				visuallyHiddenClass: 'util-visually-hidden',
-				placement: 'before',
-				wrapper: ['<div class="cmp-permalink__wrapper">', '</div>'],
-			}),
-		});
+	const md = markdownIt(markdownOptions).use(markdownItAnchor, {
+		level: 2,
+		permalink: markdownItAnchor.permalink.linkInsideHeader({
+			class: 'cmp-permalink__link',
+			renderAttrs: (slug) => ({ 'aria-labelledby': slug }),
+			symbol: '<span aria-hidden="true">#</span>',
+			placement: 'after',
+		}),
+	});
 
 	eleventyConfig.setLibrary('md', md);
 	eleventyConfig.addLayoutAlias('default', 'partials/layout.njk');

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
 			},
 			"devDependencies": {
 				"@11ty/eleventy": "^2.0.1",
+				"@11ty/eleventy-plugin-rss": "^1.2.0",
 				"@axe-core/playwright": "^4.9.0",
 				"@eslint/js": "^9.2.0",
 				"@playwright/test": "^1.43.1",
@@ -120,6 +121,21 @@
 			},
 			"engines": {
 				"node": ">=14"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/11ty"
+			}
+		},
+		"node_modules/@11ty/eleventy-plugin-rss": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-rss/-/eleventy-plugin-rss-1.2.0.tgz",
+			"integrity": "sha512-YzFnSH/5pObcFnqZ2sAQ782WmpOZHj1+xB9ydY/0j7BZ2jUNahn53VmwCB/sBRwXA/Fbwwj90q1MLo01Ru0UaQ==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^4.3.4",
+				"posthtml": "^0.16.6",
+				"posthtml-urls": "1.0.0"
 			},
 			"funding": {
 				"type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 	"license": "CC BY 4.0",
 	"devDependencies": {
 		"@11ty/eleventy": "^2.0.1",
+		"@11ty/eleventy-plugin-rss": "^1.2.0",
 		"@axe-core/playwright": "^4.9.0",
 		"@eslint/js": "^9.2.0",
 		"@playwright/test": "^1.43.1",

--- a/pages/feed.njk
+++ b/pages/feed.njk
@@ -21,8 +21,7 @@
 		<atom:link href="{{ permalink | absoluteUrl(metadata.url) }}" rel="self" type="application/rss+xml" />
 		<description>{{ metadata.subtitle }}</description>
 		<language>{{ metadata.language }}</language>
-		{%- set sortedPosts = collections.writing | reverse %}
-		{%- for post in sortedPosts | batch(10) | first %}
+		{%- for post in collections.writing | reverse | batch(10) | first %}
 		{%- set absolutePostUrl = post.url | absoluteUrl(metadata.url) %}
 		<item>
 			<title>{{ post.data.articleTitle }}</title>

--- a/pages/feed.njk
+++ b/pages/feed.njk
@@ -4,7 +4,7 @@
 	"eleventyExcludeFromCollections": true,
 	"metadata": {
 		"title": "Dustin Whisman",
-		"subtitle": "The collected writings of Dustin Whisman, full stack developer.",
+		"subtitle": "The collected writings of Dustin Whisman, web developer.",
 		"language": "en",
 		"url": "https://dustinwhisman.com",
 		"author": {
@@ -21,7 +21,8 @@
 		<atom:link href="{{ permalink | absoluteUrl(metadata.url) }}" rel="self" type="application/rss+xml" />
 		<description>{{ metadata.subtitle }}</description>
 		<language>{{ metadata.language }}</language>
-		{%- for post in collections.writing | reverse %}
+		{%- set sortedPosts = collections.writing | reverse %}
+		{%- for post in sortedPosts | batch(10) | first %}
 		{%- set absolutePostUrl = post.url | absoluteUrl(metadata.url) %}
 		<item>
 			<title>{{ post.data.articleTitle }}</title>

--- a/pages/feed.njk
+++ b/pages/feed.njk
@@ -18,18 +18,18 @@
 	<channel>
 		<title>{{ metadata.title }}</title>
 		<link>{{ metadata.url }}</link>
-		<atom:link href="{{ metadata.url }}/{{ permalink }}" rel="self" type="application/rss+xml" />
+		<atom:link href="{{ permalink | absoluteUrl(metadata.url) }}" rel="self" type="application/rss+xml" />
 		<description>{{ metadata.subtitle }}</description>
 		<language>{{ metadata.language }}</language>
 		{%- for post in collections.writing | reverse %}
-		{%- set absolutePostUrl = metadata.url + post.url %}
+		{%- set absolutePostUrl = post.url | absoluteUrl(metadata.url) %}
 		<item>
 			<title>{{ post.data.articleTitle }}</title>
 			<link>{{ absolutePostUrl }}</link>
-			<description>{{ post.data.description }}</description>
-			<pubDate>{{ post.date.toUTCString() }}</pubDate>
 			<dc:creator>{{ metadata.author.name }}</dc:creator>
+			<pubDate>{{ post.date.toUTCString() }}</pubDate>
 			<guid>{{ absolutePostUrl }}</guid>
+			<description>{{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}</description>
 		</item>
 		{%- endfor %}
 	</channel>

--- a/pages/index.njk
+++ b/pages/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Dustin Whisman - Web Developer
-description: Hi, I'm Dustin. I'm a full stack developer, which means I write HTML, CSS, and JavaScript, among other related tooling and frameworks.
+description: Hi, I'm Dustin. I'm a web developer, which means I write HTML, CSS, and JavaScript, among other related tooling and frameworks.
 layout: default
 ---
 

--- a/pages/writing/supporting-a-full-text-rss-feed.md
+++ b/pages/writing/supporting-a-full-text-rss-feed.md
@@ -1,0 +1,63 @@
+---
+title: "Supporting a full-text RSS feed - Writing - Dustin Whisman"
+description: "Up until now, I've only included a short description for posts in my RSS feed, but I've changed tactics so fellow RSS perverts can choose to read my stuff in their reader of choice."
+articleTitle: "Supporting a full-text RSS feed"
+layout: default
+date: 2024-05-08T00:00:00.000Z
+tags:
+  - writing
+---
+
+# Supporting a full-text RSS feed
+
+{% include 'partials/published-date.njk' %}
+
+Inspired by [404Media's recent support](https://404media.co/404-media-now-has-a-full-text-rss-feed/) for full-text RSS feeds for their subscribers, as well as a [recent Piccalilli post](https://piccalil.li/blog/full-text-rss-is-back), I've decided to hop on the bandwagon and update my RSS feed to be full-text.
+
+_Apologies in advance for any RSS spam from my feed. I'm pretty sure this update shouldn't flood your feed reader with my posts, but RSS readers are many and varied, so your mileage may vary._
+
+## The technical details
+
+When I set up my feed while building my site, I more or less copied the code from [11ty's docs for RSS feeds](https://www.11ty.dev/docs/plugins/rss/) but with some modifications because I didn't want to install a plugin. Here's what the chunk responsible for writing each post to the feed looked like (written in Nunjucks).
+
+```xml
+{% raw %}{%- for post in collections.writing | reverse %}
+	{%- set absolutePostUrl = metadata.url + post.url %}
+	<item>
+		<title>{{ post.data.articleTitle }}</title>
+		<link>{{ absolutePostUrl }}</link>
+		<description>{{ post.data.description }}</description>
+		<pubDate>{{ post.date.toUTCString() }}</pubDate>
+		<dc:creator>{{ metadata.author.name }}</dc:creator>
+		<guid>{{ absolutePostUrl }}</guid>
+	</item>
+{%- endfor %}{% endraw %}
+```
+
+The noteworthy part is the `post.data.description` piece, which was reading from a front-matter field that I include on all my posts and represents a short description of whatever that post is about. To support full-text, I needed to replace that with the full post content, and in order to do that without breaking any links or images, I'd need to replace all relative path URLs with absolute URLs.
+
+So I ended up downloading the `@11ty/eleventy-plugin-rss` plugin after all. That let me dynamically construct the `absolutePostUrl` in a less hacky way, and it let me replace URLs in post content by using the `htmlToAbsoluteUrls` filter that the plugin provides.
+
+After doing that, the output `feed.xml` file ended up being around 1.27 MB, which isn't terrible compared to your typical page weight these days, but I figure that number is only going to grow over time, so I decided to limit the feed to the most recent 10 posts. Any sufficiently motivated reader should be able to find my older stuff if they want to.
+
+I ran into some weird Nunjucks behavior along the way, though. I had assumed that the [`slice` filter](https://mozilla.github.io/nunjucks/templating.html#slice) would work the same way that [`Array.prototype.slice()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice) works in JavaScript, but it does not. It ends up creating an array of arrays—I guess slicing the main array into _n_ arrays, which is not what I wanted. After some flailing around, I landed on using the [`batch` filter](https://mozilla.github.io/nunjucks/templating.html#batch), which does sort of the same thing, but batches the sub-arrays into groups of _n_ (10 in my case). Then I use the [`first` filter](https://mozilla.github.io/nunjucks/templating.html#first) to discard the other arrays I don't need. A little hacky, but it works.
+
+Here's the same section updated for full-text support.
+
+```xml
+{% raw %}{%- for post in collections.writing | reverse | batch(10) | first %}
+	{%- set absolutePostUrl = post.url | absoluteUrl(metadata.url) %}
+	<item>
+		<title>{{ post.data.articleTitle }}</title>
+		<link>{{ absolutePostUrl }}</link>
+		<dc:creator>{{ metadata.author.name }}</dc:creator>
+		<pubDate>{{ post.date.toUTCString() }}</pubDate>
+		<guid>{{ absolutePostUrl }}</guid>
+		<description>{{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}</description>
+	</item>
+{%- endfor %}{% endraw %}
+```
+
+## When in doubt, let people choose
+
+My previous setup was overly restrictive and imposed my preferences on readers. I like to read posts in the browser where I can see the result of all the work that people put into their sites' styles, animations, etc. but that's just, like, my opinion, man. A lot of people like to read posts right in their feed readers, and they should be able to do so.

--- a/src/css/components/_permalink.css
+++ b/src/css/components/_permalink.css
@@ -1,9 +1,3 @@
-.cmp-permalink__wrapper {
-	display: flex;
-	align-items: center;
-	gap: 1ch;
-}
-
 .cmp-permalink__link {
 	font-weight: 700;
 	text-decoration: none;
@@ -11,7 +5,7 @@
 }
 
 @media (hover: hover) {
-	.cmp-permalink__wrapper:not(:hover) .cmp-permalink__link:not(:focus) {
+	:not(:hover) .cmp-permalink__link:not(:focus) {
 		opacity: 0;
 	}
 }


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
This sets up my RSS feed to support full text for people who prefer to read in their feed readers. To keep the file from becoming absolutely massive, I'm limiting the feed to the most recent 10 posts.

### To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
<!-- Add additional validation steps here -->
